### PR TITLE
refactor: replace asm! with llvm_asm!

### DIFF
--- a/src/asm.rs
+++ b/src/asm.rs
@@ -7,7 +7,7 @@ macro_rules! instruction {
         pub unsafe fn $fnname() {
             match () {
                 #[cfg(all(riscv, feature = "inline-asm"))]
-                () => asm!($asm :::: "volatile"),
+                () => llvm_asm!($asm :::: "volatile"),
 
                 #[cfg(all(riscv, not(feature = "inline-asm")))]
                 () => {
@@ -58,7 +58,7 @@ instruction!(
 pub unsafe fn sfence_vma(asid: usize, addr: usize) {
     match () {
         #[cfg(all(riscv, feature = "inline-asm"))]
-        () => asm!("sfence.vma $0, $1" :: "r"(asid), "r"(addr) :: "volatile"),
+        () => llvm_asm!("sfence.vma $0, $1" :: "r"(asid), "r"(addr) :: "volatile"),
 
         #[cfg(all(riscv, not(feature = "inline-asm")))]
         () => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,7 +18,7 @@
 #![no_std]
 #![deny(warnings)]
 #![feature(nll)]
-#![cfg_attr(feature = "inline-asm", feature(asm))]
+#![cfg_attr(feature = "inline-asm", feature(llvm_asm))]
 
 extern crate bare_metal;
 #[macro_use]

--- a/src/register/macros.rs
+++ b/src/register/macros.rs
@@ -7,7 +7,7 @@ macro_rules! read_csr {
                 #[cfg(all(riscv, feature = "inline-asm"))]
                 () => {
                     let r: usize;
-                    asm!("csrrs $0, $1, x0" : "=r"(r) : "i"($csr_number) :: "volatile");
+                    llvm_asm!("csrrs $0, $1, x0" : "=r"(r) : "i"($csr_number) :: "volatile");
                     r
                 }
 
@@ -36,7 +36,7 @@ macro_rules! read_csr_rv32 {
                 #[cfg(all(riscv32, feature = "inline-asm"))]
                 () => {
                     let r: usize;
-                    asm!("csrrs $0, $1, x0" : "=r"(r) : "i"($csr_number) :: "volatile");
+                    llvm_asm!("csrrs $0, $1, x0" : "=r"(r) : "i"($csr_number) :: "volatile");
                     r
                 }
 
@@ -102,7 +102,7 @@ macro_rules! write_csr {
         unsafe fn _write(bits: usize) {
             match () {
                 #[cfg(all(riscv, feature = "inline-asm"))]
-                () => asm!("csrrw x0, $1, $0" :: "r"(bits), "i"($csr_number) :: "volatile"),
+                () => llvm_asm!("csrrw x0, $1, $0" :: "r"(bits), "i"($csr_number) :: "volatile"),
 
                 #[cfg(all(riscv, not(feature = "inline-asm")))]
                 () => {
@@ -140,7 +140,7 @@ macro_rules! set {
         unsafe fn _set(bits: usize) {
             match () {
                 #[cfg(all(riscv, feature = "inline-asm"))]
-                () => asm!("csrrs x0, $1, $0" :: "r"(bits), "i"($csr_number) :: "volatile"),
+                () => llvm_asm!("csrrs x0, $1, $0" :: "r"(bits), "i"($csr_number) :: "volatile"),
 
                 #[cfg(all(riscv, not(feature = "inline-asm")))]
                 () => {
@@ -166,7 +166,7 @@ macro_rules! clear {
         unsafe fn _clear(bits: usize) {
             match () {
                 #[cfg(all(riscv, feature = "inline-asm"))]
-                () => asm!("csrrc x0, $1, $0" :: "r"(bits), "i"($csr_number) :: "volatile"),
+                () => llvm_asm!("csrrc x0, $1, $0" :: "r"(bits), "i"($csr_number) :: "volatile"),
 
                 #[cfg(all(riscv, not(feature = "inline-asm")))]
                 () => {


### PR DESCRIPTION
I am working on replace asm! with llvm_asm! for [rCore_tutorial](https://github.com/rcore-os/rCore_tutorial) and rCore_tutorial docs.

So I need to update this repo first.