### PR TITLE
Fix page faults on QEMU

### DIFF
--- a/src/paging/page_table.rs
+++ b/src/paging/page_table.rs
@@ -125,9 +125,7 @@ impl PTE for PageTableEntryX32 {
     fn frame<T: PhysicalAddress>(&self) -> FrameWith<T> {
         FrameWith::of_addr(self.addr())
     }
-    fn set<T: PhysicalAddress>(&mut self, frame: FrameWith<T>, mut flags: PageTableFlags) {
-        // U540 will raise page fault when accessing page with A=0 or D=0
-        flags |= EF::ACCESSED | EF::DIRTY;
+    fn set<T: PhysicalAddress>(&mut self, frame: FrameWith<T>, flags: PageTableFlags) {
         self.0 = ((frame.number() << 10) | flags.bits()) as u32;
     }
     fn flags_mut(&mut self) -> &mut PageTableFlags {
@@ -169,9 +167,7 @@ impl PTE for PageTableEntryX64 {
     fn frame<T: PhysicalAddress>(&self) -> FrameWith<T> {
         FrameWith::of_addr(self.addr())
     }
-    fn set<T: PhysicalAddress>(&mut self, frame: FrameWith<T>, mut flags: PageTableFlags) {
-        // U540 will raise page fault when accessing page with A=0 or D=0
-        flags |= EF::ACCESSED | EF::DIRTY;
+    fn set<T: PhysicalAddress>(&mut self, frame: FrameWith<T>, flags: PageTableFlags) {
         self.0 = ((frame.number() << 10) | flags.bits()) as u64;
     }
     fn flags_mut(&mut self) -> &mut PageTableFlags {
@@ -248,5 +244,3 @@ bitflags! {
         const RESERVED2 =   1 << 9;
     }
 }
-
-type EF = PageTableFlags;


### PR DESCRIPTION
### Conformance to the RISC-V standard

As per the RISC-V manual (20211203):

> For non-leaf PTEs, the D, A, and U bits are reserved for future standard use. Until their use is
> defined by a standard extension, they must be cleared by software for forward compatibility.

The current implementation blindly sets the D and A bits for all PTEs including non-leaf ones,
which, worked totally fine until QEMU starts to enforce this requirement in [b6ecc63c](https://github.com/qemu/qemu/commit/b6ecc63c569bb88c0fcadf79fb92bf4b88aefea8) (that is, for 7.0.0 versions and up):

> target/riscv: add PTE_A/PTE_D/PTE_U bits check for inner PTE
>
> For non-leaf PTEs, the D, A, and U bits are reserved for future standard use.

### U540 Compatibility

Yes, the hardware might still raise page faults when it does not support writing to A/D bits at all.

> If pte.a = 0, or if the original memory access is a store and pte.d = 0, either raise a page-fault
> exception corresponding to the original access type, or ...

But instead of in a utility library I presume that this should be handled by the OS (for example,
by setting the A/D bits or simulating the behavior in their trap handler).

But anyway, this is a breaking change.